### PR TITLE
Only delay between write commands for as much time as needed

### DIFF
--- a/src/DFPlayer.cpp
+++ b/src/DFPlayer.cpp
@@ -1138,7 +1138,13 @@ void DFPlayer::_sendData(uint8_t command, uint8_t dataMSB, uint8_t dataLSB)
 
       _serial->write(_dataBuffer, DFPLAYER_UART_FRAME_SIZE);
 
-      if (_moduleType == DFPLAYER_HW_247A) {delay(_threshold);}    //GD3200B/MH2024K chip so slow & need delay after write command
+      if (_moduleType == DFPLAYER_HW_247A) {    //GD3200B/MH2024K chip so slow & need delay after write command      
+            long waitTime = _threshold - (millis() - _lastSentMs);
+            if (waitTime>0) {
+              delay(waitTime);
+            }            
+            _lastSentMs = millis();
+      }
       break;
 
     case DFPLAYER_NO_CHECKSUM:

--- a/src/DFPlayer.cpp
+++ b/src/DFPlayer.cpp
@@ -1136,9 +1136,16 @@ void DFPlayer::_sendData(uint8_t command, uint8_t dataMSB, uint8_t dataLSB)
 
       _dataBuffer[9] = DFPLAYER_UART_END_BYTE;
 
+      if (_moduleType == DFPLAYER_HW_247A) {    //GD3200B/MH2024K chip so slow & need delay between write commands      
+            long waitTime = _threshold - (millis() - _lastSentMs);
+            if (waitTime>0) {
+              delay(waitTime);
+            }            
+            _lastSentMs = millis();
+      }
+
       _serial->write(_dataBuffer, DFPLAYER_UART_FRAME_SIZE);
 
-      if (_moduleType == DFPLAYER_HW_247A) {delay(_threshold);}    //GD3200B/MH2024K chip so slow & need delay after write command
       break;
 
     case DFPLAYER_NO_CHECKSUM:

--- a/src/DFPlayer.h
+++ b/src/DFPlayer.h
@@ -178,7 +178,8 @@ class DFPlayer
    uint8_t              _dataBuffer[DFPLAYER_UART_FRAME_SIZE]; //shared buffer between TX & RX
    DFPLAYER_MODULE_TYPE _moduleType;                           //DFPlayer or Clone, differ in how checksum is calculated
    bool                 _ack;                                  //true=request response from module after the command
-
+   unsigned long        _lastSentMs;                           //timestamp of last command sent
+    
    uint16_t _getResponse(uint8_t command);
    void     _sendData(uint8_t command, uint8_t dataMSB, uint8_t dataLSB);
    bool     _readData();


### PR DESCRIPTION
In case of DFPLAYER_HW_247A a blocking delay (_threshold value) was enforced after sending a write command. By keeping track of the timestamp of the last write command sent, this delay can be reduced by checking before every new command how much time has passed since the last and only blocking for as long as needed until the threshold value is reached.